### PR TITLE
add non-hidden tmux.conf to auto-mode-alist

### DIFF
--- a/tmux-mode.el
+++ b/tmux-mode.el
@@ -465,7 +465,7 @@ See `smie-rules-function' for description of KIND and TOKEN."
   (setq-local syntax-propertize-function #'tmux-mode--syntax-propertize))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist (cons "\\.tmux\\.conf\\'" 'tmux-mode))
+(add-to-list 'auto-mode-alist (cons "\\.?tmux\\.conf\\'" 'tmux-mode))
 
 (provide 'tmux-mode)
 ;; Local Variables:


### PR DESCRIPTION
Thanks for this package.

In recent versions of tmux, the config file can be $XDG_CONFIG_HOME/tmux/tmux.conf